### PR TITLE
fix typo and maintain consistency across header files

### DIFF
--- a/external/ed25519/fe.h
+++ b/external/ed25519/fe.h
@@ -3,11 +3,11 @@
 //
 // Please see the included LICENSE file for more information.
 
-#ifndef FE_H
-#define FE_H
+#ifndef ED25519_FE_H
+#define ED25519_FE_H
 
 #include <stdint.h>
 
 typedef int32_t fe[10];
 
-#endif // FE_H
+#endif // ED25519_FE_H

--- a/external/ed25519/fe_add.h
+++ b/external/ed25519/fe_add.h
@@ -3,11 +3,11 @@
 //
 // Please see the included LICENSE file for more information.
 
-#ifndef ED25519_FEE_ADD_H
-#define ED25519_FEE_ADD_H
+#ifndef ED25519_FE_ADD_H
+#define ED25519_FE_ADD_H
 
 #include "fe.h"
 
 void fe_add(fe h, const fe f, const fe g);
 
-#endif // ED25519_FEE_ADD_H
+#endif // ED25519_FE_ADD_H

--- a/external/ed25519/fe_frombytes.c
+++ b/external/ed25519/fe_frombytes.c
@@ -5,7 +5,7 @@
 
 #include "fe_frombytes.h"
 
-void fe_frombytes(fe h,const unsigned char *s)
+void fe_frombytes(fe h, const unsigned char *s)
 {
     int64_t h0 = load_4(s);
     int64_t h1 = load_3(s + 4) << 6;
@@ -28,17 +28,37 @@ void fe_frombytes(fe h,const unsigned char *s)
     int64_t carry8;
     int64_t carry9;
 
-    carry9 = (h9 + (int64_t) (1<<24)) >> 25; h0 += carry9 * 19; h9 -= carry9 << 25;
-    carry1 = (h1 + (int64_t) (1<<24)) >> 25; h2 += carry1; h1 -= carry1 << 25;
-    carry3 = (h3 + (int64_t) (1<<24)) >> 25; h4 += carry3; h3 -= carry3 << 25;
-    carry5 = (h5 + (int64_t) (1<<24)) >> 25; h6 += carry5; h5 -= carry5 << 25;
-    carry7 = (h7 + (int64_t) (1<<24)) >> 25; h8 += carry7; h7 -= carry7 << 25;
+    carry9 = (h9 + (int64_t)(1 << 24)) >> 25;
+    h0 += carry9 * 19;
+    h9 -= carry9 << 25;
+    carry1 = (h1 + (int64_t)(1 << 24)) >> 25;
+    h2 += carry1;
+    h1 -= carry1 << 25;
+    carry3 = (h3 + (int64_t)(1 << 24)) >> 25;
+    h4 += carry3;
+    h3 -= carry3 << 25;
+    carry5 = (h5 + (int64_t)(1 << 24)) >> 25;
+    h6 += carry5;
+    h5 -= carry5 << 25;
+    carry7 = (h7 + (int64_t)(1 << 24)) >> 25;
+    h8 += carry7;
+    h7 -= carry7 << 25;
 
-    carry0 = (h0 + (int64_t) (1<<25)) >> 26; h1 += carry0; h0 -= carry0 << 26;
-    carry2 = (h2 + (int64_t) (1<<25)) >> 26; h3 += carry2; h2 -= carry2 << 26;
-    carry4 = (h4 + (int64_t) (1<<25)) >> 26; h5 += carry4; h4 -= carry4 << 26;
-    carry6 = (h6 + (int64_t) (1<<25)) >> 26; h7 += carry6; h6 -= carry6 << 26;
-    carry8 = (h8 + (int64_t) (1<<25)) >> 26; h9 += carry8; h8 -= carry8 << 26;
+    carry0 = (h0 + (int64_t)(1 << 25)) >> 26;
+    h1 += carry0;
+    h0 -= carry0 << 26;
+    carry2 = (h2 + (int64_t)(1 << 25)) >> 26;
+    h3 += carry2;
+    h2 -= carry2 << 26;
+    carry4 = (h4 + (int64_t)(1 << 25)) >> 26;
+    h5 += carry4;
+    h4 -= carry4 << 26;
+    carry6 = (h6 + (int64_t)(1 << 25)) >> 26;
+    h7 += carry6;
+    h6 -= carry6 << 26;
+    carry8 = (h8 + (int64_t)(1 << 25)) >> 26;
+    h9 += carry8;
+    h8 -= carry8 << 26;
 
     h[0] = (int32_t)h0;
     h[1] = (int32_t)h1;

--- a/external/ed25519/fe_frombytes.h
+++ b/external/ed25519/fe_frombytes.h
@@ -10,6 +10,6 @@
 #include "load_3.h"
 #include "load_4.h"
 
-void fe_frombytes(fe h,const unsigned char *s);
+void fe_frombytes(fe h, const unsigned char *s);
 
-#endif //ED25519_FE_FROMBYTES_H
+#endif // ED25519_FE_FROMBYTES_H

--- a/external/ed25519/fe_mul.h
+++ b/external/ed25519/fe_mul.h
@@ -8,6 +8,6 @@
 
 #include "fe.h"
 
-void fe_mul(fe, const fe, const fe);
+void fe_mul(fe h, const fe f, const fe g);
 
 #endif // ED25519_FE_MUL_H

--- a/external/ed25519/fe_tobytes.h
+++ b/external/ed25519/fe_tobytes.h
@@ -8,6 +8,6 @@
 
 #include "fe.h"
 
-void fe_tobytes(unsigned char *, const fe);
+void fe_tobytes(unsigned char *s, const fe h);
 
 #endif // ED25519_FE_TOBYTES_H

--- a/external/ed25519/ge.h
+++ b/external/ed25519/ge.h
@@ -3,8 +3,8 @@
 //
 // Please see the included LICENSE file for more information.
 
-#ifndef GE_H
-#define GE_H
+#ifndef ED25519_GE_H
+#define ED25519_GE_H
 
 #include "fe.h"
 
@@ -48,4 +48,4 @@ typedef struct
 
 typedef ge_cached ge_dsmp[8];
 
-#endif // GE_H
+#endif // ED25519_GE_H

--- a/external/ed25519/ge_add.h
+++ b/external/ed25519/ge_add.h
@@ -3,14 +3,14 @@
 //
 // Please see the included LICENSE file for more information.
 
-#ifndef GE_ADD_H
-#define GE_ADD_H
+#ifndef ED25519_GE_ADD_H
+#define ED25519_GE_ADD_H
 
 #include "fe_add.h"
 #include "fe_mul.h"
 #include "fe_sub.h"
 #include "ge.h"
 
-void ge_add(ge_p1p1 *, const ge_p3 *, const ge_cached *);
+void ge_add(ge_p1p1 *r, const ge_p3 *p, const ge_cached *q);
 
-#endif // GE_ADD_H
+#endif // ED25519_GE_ADD_H

--- a/external/ed25519/ge_madd.h
+++ b/external/ed25519/ge_madd.h
@@ -11,6 +11,6 @@
 #include "fe_sub.h"
 #include "ge.h"
 
-void ge_madd(ge_p1p1 *, const ge_p3 *, const ge_precomp *);
+void ge_madd(ge_p1p1 *r, const ge_p3 *p, const ge_precomp *q);
 
 #endif // ED25519_GE_MADD_H

--- a/external/ed25519/ge_scalarmult_base.h
+++ b/external/ed25519/ge_scalarmult_base.h
@@ -7,6 +7,7 @@
 #define ED25519_GE_SCALARMULT_BASE_H
 
 #include "equal.h"
+#include "fe_copy.h"
 #include "fe_neg.h"
 #include "ge.h"
 #include "ge_madd.h"

--- a/external/ed25519/sc_check.c
+++ b/external/ed25519/sc_check.c
@@ -16,14 +16,6 @@ int sc_check(const unsigned char *s)
     int64_t s6 = load_4(s + 24);
     int64_t s7 = load_4(s + 28);
 
-    return (int)(
-      (signum(1559614444 - s0)
-      + (signum(1477600026 - s1) << 1)
-      + (signum(2734136534 - s2) << 2)
-      + (signum(350157278 - s3) << 3)
-      + (signum(-s4) << 4)
-      + (signum(-s5) << 5)
-      + (signum(-s6) << 6)
-      + (signum(268435456 - s7) << 7)) >> 8
-    );
+    return (
+        int)((signum(1559614444 - s0) + (signum(1477600026 - s1) << 1) + (signum(2734136534 - s2) << 2) + (signum(350157278 - s3) << 3) + (signum(-s4) << 4) + (signum(-s5) << 5) + (signum(-s6) << 6) + (signum(268435456 - s7) << 7)) >> 8);
 }


### PR DESCRIPTION
* Fixed typo in **fe_add.h** header macro
* Changed header macros of **fe.h**, **ge.h** and **ge_add.h** to maintain consistency with other header files
* Added variable names to function signatures in **fe_mul.h**, **fe_tobytes.h**, **ge_add.h** and **ge_madd.h** to maintain consistency with other header files
* Added missing header file **ge_scalarmult_base.h**
* Applied clang-format to files **fe_frombytes.c** and **sc_check.c**